### PR TITLE
Fix definition of scatt1 in Overview.ipynb

### DIFF
--- a/notebooks/Overview.ipynb
+++ b/notebooks/Overview.ipynb
@@ -234,7 +234,8 @@
    },
    "outputs": [],
    "source": [
-    "scatt1 = f1.add_scatter(x=iris_df.sepal_length, y=iris_df.petal_width)"
+    "f1.add_scatter(x=iris_df.sepal_length, y=iris_df.petal_width)\n",
+    "scatt1 = f1.data[0]"
    ]
   },
   {


### PR DESCRIPTION
`f1.add_scatter` is returning a `plotly.graph_objs._figurewidget.FigureWidget`, which is not the scatter plot, which is a `plotly.graph_objs._scatter.Scatter`.

There's actually already a correct instance of this pattern in the code further below:
```
scatt2 = f2.data[0]
```